### PR TITLE
🎨 Palette: Improve accessibility of links and navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-05-14 - Visual Rating and Semantic Lists
 **Learning:** Using Unicode characters (★, ☆, ✓, ✖) provides immediate visual feedback and improves the "skimmability" of reviews. Accessibility is maintained by using ARIA roles and labels, and ensuring the correct charset is set in the layout.
 **Action:** Always include `<meta charset="utf-8">` when using Unicode symbols, and use `aria-hidden="true"` on decorative icons while providing an `aria-label` on the container.
+
+## 2025-05-15 - Contextual Link Labels and Navigation Semantics
+**Learning:** Repetitive links like "Read more" or "Read the full review" are ambiguous for screen reader users when presented out of context (e.g., in a links list). Providing specific `aria-label`s that include the item's title significantly improves accessibility. Additionally, using `aria-current="page"` and `aria-label` on `<nav>` elements helps users understand their current location and the purpose of navigation regions.
+**Action:** Always provide contextual labels for repetitive links using the item's title, and ensure navigation regions are properly labeled and stateful.

--- a/_drafts/house/creating-a-whiteboard-wall-with-rust-oleum-dry-erase-paint.markdown
+++ b/_drafts/house/creating-a-whiteboard-wall-with-rust-oleum-dry-erase-paint.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Creating a Whiteboard Wall with Rust-Oleum Dry Erase Paint: My Journey to a Writeable Surface"
-date: 
+date: 2025-05-15
 categories: [home improvement, DIY]
 tags: [whiteboard, dry erase paint, Rust-Oleum, home office, smart home]
 ---

--- a/_includes/site-nav.html
+++ b/_includes/site-nav.html
@@ -1,11 +1,15 @@
-<nav class="nav">
+<nav class="nav" aria-label="Main navigation">
   <ul class="list list--nav">
-    <li class="item item--nav{% if page.url == '/' %} item--current{% endif %}"><a href="{{ '/' | relative_url }}">Home</a></li>
-    <li class="item item--nav{% if page.url == '/about/' %} item--current{% endif %}"><a href="{{ '/about/' | relative_url }}">About</a></li>
+    <li class="item item--nav{% if page.url == '/' %} item--current{% endif %}">
+      <a href="{{ '/' | relative_url }}"{% if page.url == '/' %} aria-current="page"{% endif %}>Home</a>
+    </li>
+    <li class="item item--nav{% if page.url == '/about/' %} item--current{% endif %}">
+      <a href="{{ '/about/' | relative_url }}"{% if page.url == '/about/' %} aria-current="page"{% endif %}>About</a>
+    </li>
     {% assign builder_pages = site.pages | where_exp: "page", "page.path contains 'builders/'" | sort: "rating" %}
     {% for item in builder_pages %}
       <li class="item item--nav{% if item.url == page.url %} item--current{% endif %}">
-        <a href="{{ item.url | relative_url }}">{{ item.title }}</a>
+        <a href="{{ item.url | relative_url }}"{% if item.url == page.url %} aria-current="page"{% endif %}>{{ item.title }}</a>
       </li>
     {% endfor %}
   </ul>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@ permalink: /
     <h2><a href="{{ builder_page.url | relative_url }}">{{ builder_page.title }}</a></h2>
     <p><strong>Rating: {% include star-rating.html rating=builder_page.rating %}</strong></p>
     <p>{{ builder_page.content | strip_html | truncatewords: 50 }}</p>
-    <p><a href="{{ builder_page.url | relative_url }}">Read the full review...</a></p>
+    <p><a href="{{ builder_page.url | relative_url }}" aria-label="Read the full review for {{ builder_page.title | escape }}">Read the full review...</a></p>
   </div>
   <hr>
 {% endfor %}


### PR DESCRIPTION
💡 What:
Improved the accessibility of the site's navigation and builder review links.

🎯 Why:
Repetitive links like "Read the full review..." are ambiguous for screen reader users. Navigation regions without labels can be difficult to identify, and active links should be semantically marked.

♿ Accessibility:
- Added `aria-label` to builder review links using the builder's title.
- Labeled the primary `<nav>` element.
- Added `aria-current="page"` to the active navigation link.
- Ensured the site builds correctly by fixing a malformed draft date.

---
*PR created automatically by Jules for task [558809260533843291](https://jules.google.com/task/558809260533843291) started by @sparksis*